### PR TITLE
Add database engine accessor helper

### DIFF
--- a/apps/api/app/core/Database.py
+++ b/apps/api/app/core/Database.py
@@ -7,6 +7,10 @@ URLBaseDatos = "sqlite:///./datos.db"
 Motor = create_engine(URLBaseDatos, echo=False, connect_args={"check_same_thread": False})
 
 
+def ObtenerEngine():
+    return Motor
+
+
 def IniciarTablas() -> None:
     # Importar modelos para registrar metadata antes de crear tablas
     from app.models import Goal  # noqa: F401  # Usuario, Meta


### PR DESCRIPTION
## Summary
- add an ObtenerEngine helper in the database module so tests can import the configured engine

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'app' when running tests without additional environment configuration; underlying application import also raises a PydanticUserError due to deprecated `regex` argument)*

------
https://chatgpt.com/codex/tasks/task_e_68dacca38f7c8332bd87e48fb4ba67d4