### PR TITLE
Limit goal type selection to Individual or Colectiva

### DIFF
--- a/apps/mobile/__tests__/goals.service.test.ts
+++ b/apps/mobile/__tests__/goals.service.test.ts
@@ -12,7 +12,7 @@ describe('goals service', () => {
   });
 
   it('lists goals successfully', async () => {
-    mock.onGet('/metas').reply(200, [{ Id: 1, PropietarioId: 1, Titulo: 'A', TipoMeta: 'OTRA' }]);
+    mock.onGet('/metas').reply(200, [{ Id: 1, PropietarioId: 1, Titulo: 'A', TipoMeta: 'Individual' }]);
     const metas = await listGoals();
     expect(metas.length).toBe(1);
     expect(metas[0].Titulo).toBe('A');

--- a/apps/mobile/src/screens/CrearEditarMetaScreen.tsx
+++ b/apps/mobile/src/screens/CrearEditarMetaScreen.tsx
@@ -1,8 +1,8 @@
-import React, { useState } from 'react';
-import { View, Text, TextInput, StyleSheet, Button, Alert } from 'react-native';
+import React, { useMemo, useState } from 'react';
+import { View, Text, TextInput, StyleSheet, Button, Alert, Pressable } from 'react-native';
 import { showError, showSuccess } from '../ui/toast';
 import { logEvent } from '../telemetry';
-import { createGoal, updateGoal } from '../services/goals';
+import { createGoal, updateGoal, GOAL_TYPES, normalizeGoalType, type GoalType } from '../services/goals';
 import { useNavigation, useRoute, RouteProp } from '@react-navigation/native';
 import { useQueryClient } from '@tanstack/react-query';
 
@@ -14,25 +14,44 @@ export default function CrearEditarMetaScreen(): React.ReactElement {
   const meta = ruta.params?.meta;
   const cliente = useQueryClient();
   const [Titulo, EstablecerTitulo] = useState('');
-  const [TipoMeta, EstablecerTipoMeta] = useState('SALUD');
+  const [TipoMeta, EstablecerTipoMeta] = useState<GoalType>(normalizeGoalType());
   const [Descripcion, EstablecerDescripcion] = useState('');
   const [Guardando, SetGuardando] = useState(false);
 
   React.useEffect(() => {
     if (meta) {
       EstablecerTitulo(meta.Titulo ?? '');
-      EstablecerTipoMeta(meta.TipoMeta ?? '');
+      EstablecerTipoMeta(normalizeGoalType(meta.TipoMeta));
       EstablecerDescripcion(meta.Descripcion ?? '');
     }
   }, [meta]);
+
+  const tiposMeta = useMemo(() => GOAL_TYPES, []);
 
   return (
     <View style={Estilos.Contenedor}>
       <Text style={Estilos.TituloPantalla}>Crear / Editar Meta</Text>
       <Text>Titulo</Text>
       <TextInput style={Estilos.Input} value={Titulo} onChangeText={EstablecerTitulo} placeholder="Ej. Correr 5km" />
-      <Text>TipoMeta</Text>
-      <TextInput style={Estilos.Input} value={TipoMeta} onChangeText={EstablecerTipoMeta} placeholder="SALUD|FINANZAS|CARRERA|OTRA" />
+      <Text>Tipo de meta</Text>
+      <View style={Estilos.SeleccionTipo}>
+        {tiposMeta.map((tipo, indice) => (
+          <Pressable
+            key={tipo}
+            accessibilityRole="button"
+            accessibilityState={{ selected: TipoMeta === tipo }}
+            onPress={() => EstablecerTipoMeta(tipo)}
+            style={[
+              Estilos.OpcionTipo,
+              indice < tiposMeta.length - 1 && Estilos.OpcionTipoSeparador,
+              TipoMeta === tipo && Estilos.OpcionTipoActiva
+            ]}
+          >
+            <Text style={[Estilos.TextoOpcion, TipoMeta === tipo && Estilos.TextoOpcionActiva]}>{tipo}</Text>
+          </Pressable>
+        ))}
+      </View>
+      <Text style={Estilos.AyudaTipo}>Selecciona si la meta es Individual o Colectiva.</Text>
       <Text>Descripcion</Text>
       <TextInput style={[Estilos.Input, { height: 80 }]} value={Descripcion} onChangeText={EstablecerDescripcion} multiline />
       <View style={Estilos.Acciones}>
@@ -49,7 +68,7 @@ export default function CrearEditarMetaScreen(): React.ReactElement {
               } catch (e: any) {
                 // rollback UI state
                 EstablecerTitulo(prev.Titulo ?? '');
-                EstablecerTipoMeta(prev.TipoMeta ?? '');
+                EstablecerTipoMeta(normalizeGoalType(prev.TipoMeta));
                 EstablecerDescripcion(prev.Descripcion ?? '');
                 logEvent('goal_save_error', { mode: 'update', Id: meta.Id, message: e?.message });
                 throw e;
@@ -78,5 +97,12 @@ const Estilos = StyleSheet.create({
   Contenedor: { flex: 1, padding: 16 },
   TituloPantalla: { fontSize: 20, fontWeight: '600', marginBottom: 12 },
   Input: { borderWidth: 1, borderColor: '#ccc', borderRadius: 8, padding: 8, marginBottom: 12 },
+  SeleccionTipo: { flexDirection: 'row', marginVertical: 8 },
+  OpcionTipo: { flex: 1, borderWidth: 1, borderColor: '#ccc', borderRadius: 8, paddingVertical: 12, alignItems: 'center', marginBottom: 4 },
+  OpcionTipoSeparador: { marginRight: 12 },
+  OpcionTipoActiva: { borderColor: '#007AFF', backgroundColor: '#E5F1FF' },
+  TextoOpcion: { fontSize: 16, color: '#333' },
+  TextoOpcionActiva: { color: '#0057B7', fontWeight: '600' },
+  AyudaTipo: { fontSize: 12, color: '#666', marginBottom: 12 },
   Acciones: { flexDirection: 'row', justifyContent: 'space-between' }
 });

--- a/apps/mobile/test/msw/handlers.ts
+++ b/apps/mobile/test/msw/handlers.ts
@@ -11,6 +11,6 @@ export const handlers = [
       { Id: 1, EventoId: 99, FechaHora: new Date(Date.now() + 3600_000).toISOString(), Canal: 'Local', Enviado: false, CreadoEn: new Date().toISOString() }
     ]);
   }),
-  http.post(`${API}/metas/:id/recuperar`, () => HttpResponse.json({ Id: 42, PropietarioId: 1, Titulo: 'Meta', TipoMeta: 'OTRA', CreadoEn: new Date().toISOString() })),
+  http.post(`${API}/metas/:id/recuperar`, () => HttpResponse.json({ Id: 42, PropietarioId: 1, Titulo: 'Meta', TipoMeta: 'Individual', CreadoEn: new Date().toISOString() })),
   http.post(`${API}/eventos/:id/recuperar`, () => HttpResponse.json({ Id: 77, MetaId: 42, PropietarioId: 1, Titulo: 'Ev', Inicio: new Date().toISOString(), Fin: new Date(Date.now()+3600_000).toISOString(), CreadoEn: new Date().toISOString() })),
 ];


### PR DESCRIPTION
## Summary
- replace the free-form goal type input on CrearEditarMeta with a controlled selector for Individual and Colectiva
- normalize and validate goal types in the goals service before creating or updating
- update mobile tests and mocks to use the supported goal type values

## Testing
- yarn test --watchAll=false *(fails: package missing from lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_68daccae99a883328e38801bcbae59a8