### PR TITLE
Fix Expo host parsing to avoid mobile API timeouts

### DIFF
--- a/apps/mobile/src/config.ts
+++ b/apps/mobile/src/config.ts
@@ -7,16 +7,29 @@ import Constants from 'expo-constants';
 // - Android (emulador): 10.0.2.2 apunta al host
 // - iOS (simulador): localhost
 // Nota: En dispositivo físico, define EXPO_PUBLIC_API_URL con la IP LAN del host.
+function extraerHost(valor: string | null | undefined): string | null {
+  if (!valor || typeof valor !== 'string') {
+    return null;
+  }
+
+  // Expo suele exponer valores como "exp://192.168.0.12:19000" o "192.168.0.12:19000"
+  // Normalizamos eliminando esquema y query params si existen.
+  const limpio = valor.split('?')[0]?.replace(/^[^:]+:\/\//, '') ?? '';
+  if (!limpio) {
+    return null;
+  }
+
+  const host = limpio.split(':')[0];
+  return host || null;
+}
+
 function resolveExpoHost(): string | null {
   try {
-    const explicit = Constants.expoConfig?.hostUri
-      ?? (Constants as any).manifest2?.extra?.expoClient?.hostUri
-      ?? (Constants as any).manifest?.debuggerHost;
-    if (explicit && typeof explicit === 'string') {
-      const host = explicit.split(':')[0];
-      if (host) {
-        return host;
-      }
+    const explicit = extraerHost(Constants.expoConfig?.hostUri)
+      ?? extraerHost((Constants as any).manifest2?.extra?.expoClient?.hostUri)
+      ?? extraerHost((Constants as any).manifest?.debuggerHost);
+    if (explicit) {
+      return explicit;
     }
   } catch (_) {
     // Ignorar: en producción Constants.manifest puede no estar disponible


### PR DESCRIPTION
## Summary
- normalize Expo host URIs when inferring the development API base URL so `exp://` prefixes no longer break the hostname detection
- keep the existing heuristics for other platforms while ensuring requests hit the running backend

## Testing
- npm test -- --watch=false

------
https://chatgpt.com/codex/tasks/task_e_68dcb1492ed483329b6419bb762bcf33